### PR TITLE
Generate correct view definition if a table shares its name with the database

### DIFF
--- a/lib/scenic/adapters/my_sql.rb
+++ b/lib/scenic/adapters/my_sql.rb
@@ -87,7 +87,7 @@ module Scenic
         execute("SHOW CREATE VIEW #{quote_table_name(name)}")
           .first[1]
           .sub(/\A.*#{quote_table_name(name)} AS /i, '')
-          .gsub(/#{quote_table_name(@connectable.connection.current_database)}\./, '')
+          .gsub(/(\s|\(|,)#{quote_table_name(@connectable.connection.current_database)}\./, '\1')
       end
     end
   end


### PR DESCRIPTION
Fix for #3 

The regex looks for either a space, an open brace or a comma before the database name, avoiding matching substrings where the database name appears twice.