### PR TITLE
Fix conflict with CircleCI config directive

### DIFF
--- a/scenic-mysql_adapter.gemspec
+++ b/scenic-mysql_adapter.gemspec
@@ -29,10 +29,10 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "scenic", ">= 1.4.0"
-  spec.add_dependency "mysql2"
 
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "appraisal"
+  spec.add_development_dependency "mysql2"
 end


### PR DESCRIPTION
Make `mysql2` a development dependency.

Avoids conflict with the `- run: echo bundle exec gem uninstall mysql2` directive in `.circleci/config.yml`.

Error message on CircleCI was:
```
#!/bin/bash -eo pipefail
bundle exec gem uninstall mysql2

You have requested to uninstall the gem:
	mysql2-0.5.2

scenic-mysql_adapter-1.0.1 depends on mysql2 (>= 0)
If you remove this gem, these dependencies will not be met.
Continue with Uninstall? [yN]
You have requested to uninstall the gem:
	mysql2-0.5.2

scenic-mysql_adapter-1.0.1 depends on mysql2 (>= 0)
If you remove this gem, these dependencies will not be met.
Continue with Uninstall? [yN]
You have requested to uninstall the gem:
	mysql2-0.5.2

scenic-mysql_adapter-1.0.1 depends on mysql2 (>= 0)
If you remove this gem, these dependencies will not be met.
Continue with Uninstall? [yN]  ERROR:  Interrupted
Too long with no output (exceeded 10m0s)
```