### PR TITLE
adding missing line to initializer in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Then create the following file:
 ```ruby
 # config/initializers/scenic.rb
 
+require 'scenic/mysql_adapter'
+
 Scenic.configure do |config|
   config.database = Scenic::Adapters::MySQL.new
 end


### PR DESCRIPTION
If this line is missing from the initializer, you can potentially get an error about Scenic::Adapters::MySQL being undefined (depending on the autoload order).

This line just ensures that it's never an issue for anyone.